### PR TITLE
Fix username default for blueprint

### DIFF
--- a/internal/controller/imagebuilderimage_controller.go
+++ b/internal/controller/imagebuilderimage_controller.go
@@ -44,6 +44,7 @@ const ubiImage = "registry.access.redhat.com/ubi9:latest"
 const utilsImage = "quay.io/cgament/composer-cli"
 const imageBuilderImageLabel = "osbuild-operator-image"
 const defaultIsoTarget = "edge-simplified-installer"
+const defaultUserName = "root"
 const defaultBlueprintTemplate = `name = "{{ .Name }}"
 version = "0.0.1"
 modules = []
@@ -198,6 +199,14 @@ func (r *ImageBuilderImageReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	imageSpec := imageBuilderImage.Spec
 	if imageSpec.Name == "" {
 		imageSpec.Name = imageBuilderImage.Name
+	}
+
+	// use default username
+	if imageBuilderImage.Spec.UserName == "" {
+		logger.Info("No defined spec.userName, using root as default")
+		imageSpec.UserName = defaultUserName
+	} else {
+		imageSpec.UserName = imageBuilderImage.Spec.UserName
 	}
 
 	// templates used for blueprints


### PR DESCRIPTION
In the ImageBuilderImage CRD, if username value is not set, compose will fail due to empty value. This PR adds a default value (root).