### PR TITLE
Replace default iso target and NGINX web server

### DIFF
--- a/internal/controller/imagebuilderimage_controller.go
+++ b/internal/controller/imagebuilderimage_controller.go
@@ -43,7 +43,7 @@ import (
 const ubiImage = "registry.access.redhat.com/ubi9:latest"
 const utilsImage = "quay.io/cgament/composer-cli"
 const imageBuilderImageLabel = "osbuild-operator-image"
-const defaultIsoTarget = "edge-simplified-installer"
+const defaultIsoTarget = "edge-installer"
 const defaultBlueprintTemplate = `name = "{{ .Name }}"
 version = "0.0.1"
 modules = []

--- a/internal/controller/imagebuilderimage_controller.go
+++ b/internal/controller/imagebuilderimage_controller.go
@@ -507,8 +507,8 @@ func (r *ImageBuilderImageReconciler) WebDeployment(objectMeta metav1.ObjectMeta
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "nginx",
-							Image: "docker.io/nginxinc/nginx-unprivileged",
+							Name:  "httpd",
+							Image: "registry.redhat.io/rhel9/httpd-24:latest",
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -523,7 +523,7 @@ func (r *ImageBuilderImageReconciler) WebDeployment(objectMeta metav1.ObjectMeta
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "data-pv",
-									MountPath: "/usr/share/nginx/html/",
+									MountPath: "/var/www/html/",
 									SubPath:   imageName,
 								},
 							},


### PR DESCRIPTION
This PR replaces the default iso target to match documentation, and also, replaces the nginx web server from Docker.io to avoid rate limits by a httpd from RH registry.